### PR TITLE
Modernize code generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
         run: brew install xcbeautify jemalloc --quiet
       - name: Run Tests
         run: |
-          set -o pipefail && xcrun swift test | xcbeautify --renderer github-actions
+          set -o pipefail && xcrun swift test --enable-experimental-prebuilts | xcbeautify --renderer github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Sources/**"
+      - "Tests/**"
+      - "TestPlans/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Sources/**"
+      - "Tests/**"
+      - "TestPlans/**"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: Lint & Format Check
+    runs-on: macOS-26
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_26.2.app/Contents/Developer"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Swift Version
+        run: xcrun swift --version
+      - name: Install SwiftLint
+        run: brew install swiftlint --quiet
+      - name: Install swift-format
+        run: brew install swiftformat --quiet
+      - name: SwiftLint
+        run: swiftlint --strict --config .swiftlint.yml .
+      - name: Swift Format Check
+        run: swiftformat --lint-only --config .swiftformat.conf . --strict
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runsOn }}
+    needs: lint
+    env:
+      DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}.app/Contents/Developer"
+    strategy:
+      matrix:
+        include:
+          - xcode: "Xcode_26.0"
+            runsOn: macOS-26
+            name: "macOS 26, SPM 6.2.0 Test"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Swift Version
+        run: xcrun swift --version
+      - name: Brew install tools
+        run: brew install xcbeautify jemalloc --quiet
+      - name: Run Tests
+        run: |
+          set -o pipefail && xcrun swift test | xcbeautify --renderer github-actions

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Kaleidoscope-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Kaleidoscope-Package.xcscheme
@@ -83,6 +83,26 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KaleidoscopeMacroSupportNextTests"
+               BuildableName = "KaleidoscopeMacroSupportNextTests"
+               BlueprintName = "KaleidoscopeMacroSupportNextTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "KaleidoscopeMacroTests"
+               BuildableName = "KaleidoscopeMacroTests"
+               BlueprintName = "KaleidoscopeMacroTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,6 @@ let package = Package(
             name: "Kaleidoscope",
             targets: ["Kaleidoscope"],
         ),
-        .executable(
-            name: "KaleidoscopeClient",
-            targets: ["KaleidoscopeClient"],
-        ),
     ],
     dependencies: [
         // Depend on the Swift 5.9 release of SwiftSyntax
@@ -40,6 +36,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+                .product(name: "MacroToolkit", package: "swift-macro-toolkit"),
                 "KaleidoscopeLexer",
                 "KaleidoscopeMacroSupport",
             ],
@@ -62,11 +59,16 @@ let package = Package(
         ),
         // tests
         .testTarget(
+            name: "KaleidoscopeMacroTests",
+            dependencies: [
+                .product(name: "MacroTesting", package: "swift-macro-testing"),
+                "KaleidoscopeMacros",
+            ],
+        ),
+        .testTarget(
             name: "KaleidoscopeTests",
             dependencies: [
-                "KaleidoscopeMacros",
                 "Kaleidoscope",
-                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ],
         ),
         .testTarget(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kaleidoscope
 
-This is a lexer inspired by [logos](https://github.com/maciejhirsz/logos). It utilizes swift macros enable easy creation.
+This is a lexer for Swift inspired by [logos](https://github.com/maciejhirsz/logos). It utilizes swift macros to generate optimized lexer code in compile time. Please see [install section](#install) for installation instructions.
 
 ## Example
 
@@ -42,18 +42,38 @@ Identifier("fast")
 Tokenizer
 ```
 
+## Install
+
+You can install Kaleidoscope via Swift Package Manager. Add the following line to your `Package.swift` file:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/FlickerSoul/kaleidoscope-lexer", from: "0.1.0")
+]
+```
+
+and add `"Kaleidoscope"` to the dependencies of your target.
+
+```swift
+.product(name: "Kaleidoscope", package: "kaleidoscope-lexer")
+```
+
+## Project Version
+
+Because the Kaleidoscope library is under active development, source-stability is only guaranteed within minor versions (e.g. between 0.0.3 and 0.0.4). If you don't want potentially source-breaking package updates, you can specify your package dependency using .upToNextMinorVersion(from: "0.0.1") instead.
+
+When the package reaches a 1.0.0 release, the public API of the kaleidoscope-lexer package will consist of non-underscored declarations that are marked public. Interfaces that aren't part of the public API may continue to change in any release, including the package’s examples, tests, utilities, and documentation.
+
+Future minor versions of the package may introduce changes to these rules as needed.
+
 ## Idea
 
 The project is provides three macros: `@kaleidoscope`, `regex`, and `token`, and they work together to generate conformance to `LexerProtocol` for the decorated  enums. `regex` takes in a regex expression for matching and `token` takes a string for excat matching. In addition, they can take a `onMatch` callback and a `priority` integer. The callback has access to token string slice and can futher transform it to whatever type required by the enum case. The priority are calculated by from the expression by default. However, if two exprssions have the same weight, manual specification is required to resolve the conflict.
 
 Internally, all regex expressions and token strings are converted into a single finite automata. The finite automata consumes one character from the input at a time, until it reaches an token match or an error. This machanism is simple but works slowly. Future improvements can be established on this issue.
 
-## Note
+## Roadmap
 
-This package uses an internal Swift package [`_RegexParser`](https://github.com/apple/swift-experimental-string-processing) included in the experimental string processing lib. Please check out the github packe for compatibility. Due to its being experimental, this library can break in the future.
-
-## Furture Improvements
-
-- [ ] faster tokenization optomization
-- [ ] cleaner code generation
-- [ ] cleaner interface
+- [ ] replace string regex argument with builtin swift regex
+- [ ] faster tokenization optimization
+- [ ] improved interface

--- a/Sources/KaleidoscopeLexer/Lexer.swift
+++ b/Sources/KaleidoscopeLexer/Lexer.swift
@@ -30,32 +30,23 @@ public protocol LexerProtocol {
     static func lexer(source: RawSource) -> LexerMachine<Self>
 }
 
-public enum TokenResult<Token: LexerProtocol>: Equatable, Into {
+public enum TokenResult<Token: LexerProtocol> {
     public typealias IntoType = Self
 
     case result(Token)
     case skipped
 
-    public static func == (lhs: TokenResult, rhs: TokenResult) -> Bool {
-        switch (lhs, rhs) {
-        case (.skipped, skipped):
-            true
-        case _:
-            false
+    var isSkip: Bool {
+        switch self {
+        case .skipped: true
+        default: false
         }
     }
+}
 
-    public static func == (lhs: TokenResult, rhs: TokenResult) -> Bool where Token: Equatable {
-        switch (lhs, rhs) {
-        case (.skipped, .skipped):
-            true
-        case let (.result(lhs), .result(rhs)):
-            lhs == rhs
-        case _:
-            false
-        }
-    }
+extension TokenResult: Equatable where Token: Equatable {}
 
+extension TokenResult: Into {
     public func into() -> TokenResult<Token> {
         self
     }
@@ -149,7 +140,7 @@ public struct LexerMachine<Token: LexerProtocol> {
 
     @inline(__always)
     public mutating func setToken(_ token: any Into<TokenResult<Token>>) throws {
-        guard self.token == nil || self.token == .skipped else {
+        guard self.token == nil || self.token?.isSkip == true else {
             throw LexerError.duplicatedToken
         }
         self.token = token.into()

--- a/Sources/KaleidoscopeMacros/Generator.swift
+++ b/Sources/KaleidoscopeMacros/Generator.swift
@@ -96,7 +96,7 @@ struct Generator {
             }
 
             try SwitchExprSyntax("switch scalar") {
-                for (nodeId, cases) in mergeCaes {
+                for (nodeId, cases) in mergeCaes.sorted(by: { $0.key < $1.key }) {
                     let caseString = cases.map { $0.toCode() }.joined(separator: ", ")
                     """
                     case \(raw: caseString):

--- a/Sources/KaleidoscopeMacros/Generator.swift
+++ b/Sources/KaleidoscopeMacros/Generator.swift
@@ -7,6 +7,7 @@
 
 import KaleidoscopeMacroSupport
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 // MARK: - Generator
 
@@ -14,76 +15,56 @@ enum GeneratorError: Error {
     case buildingEmptyNode
 }
 
-extension DefaultStringInterpolation {
-    mutating func appendInterpolation(indented string: String) {
-        let indent = String(description.reversed().prefix { $0 == " " })
-        if indent.isEmpty {
-            appendInterpolation(string)
-        } else {
-            appendLiteral(string.split(separator: "\n", omittingEmptySubsequences: false)
-                .joined(separator: "\n" + indent))
-        }
-    }
-}
-
 /// Generates the lexer code
 struct Generator {
     let graph: Graph
     let enumIdent: String
-    var functionMapping: [Int: String] = [:]
 
-    mutating func buildNodeFunctions() throws {
+    @CodeBlockItemListBuilder
+    mutating func buildFunctions() throws -> CodeBlockItemListSyntax {
         for (nodeId, node) in graph.nodes.enumerated() {
-            let body: String
-            switch node {
-            case let .leaf(content):
-                body = buildLeaf(node: content)
-            case let .branch(content):
-                body = buildBranch(node: content)
-            case let .seq(content):
-                body = buildSeq(node: content)
-            case .none:
-                throw GeneratorError.buildingEmptyNode
-            }
-
             let ident = generateFuncIdent(nodeId: nodeId)
 
-            functionMapping[nodeId] = """
-            func \(ident) (_ lexer: inout LexerMachine<Self>) throws {
-                \(indented: body)
+            try FunctionDeclSyntax("func \(raw: ident)(_ lexer: inout LexerMachine<Self>) throws") {
+                switch node {
+                case let .leaf(content):
+                    buildLeaf(node: content)
+                case let .branch(content):
+                    try buildBranch(node: content)
+                case let .seq(content):
+                    try buildSeq(node: content)
+                case nil:
+                    throw GeneratorError.buildingEmptyNode
+                }
             }
-            """
         }
-    }
-
-    mutating func buildFunctions() throws -> String {
-        try buildNodeFunctions()
-        return functionMapping.values.joined(separator: "\n")
     }
 
     /// Generate leaf lexer handles, based on the token type
     /// - Parameters:
     ///     - node: the leaf graph node
-    func buildLeaf(node: Node.LeafContent) -> String {
+    func buildLeaf(node: Node.LeafContent) -> CodeBlockItemListSyntax {
         let end = graph.inputs[node.endId]
-        switch end.tokenType {
-        case .skip:
-            return "try lexer.skip()"
-        case .standalone:
-            return "try lexer.setToken(\(enumIdent).\(end.token))"
-        case let .fillCallback(callbackDetail):
-            switch callbackDetail {
-            case let .named(ident):
-                return "try lexer.setToken(\(enumIdent).\(end.token)(\(ident)(&lexer)))"
-            case let .lambda(lambda):
-                return "try lexer.setToken(\(enumIdent).\(end.token)(\(lambda)(&lexer)))"
-            }
-        case let .createCallback(callbackDetail):
-            switch callbackDetail {
-            case let .named(ident):
-                return "try lexer.setToken(\(ident)(&lexer))"
-            case let .lambda(lambda):
-                return "try lexer.setToken(\(lambda)(&lexer))"
+        return CodeBlockItemListSyntax {
+            switch end.tokenType {
+            case .skip:
+                "try lexer.skip()"
+            case .standalone:
+                "try lexer.setToken(\(raw: enumIdent).\(raw: end.token))"
+            case let .fillCallback(callbackDetail):
+                switch callbackDetail {
+                case let .named(ident):
+                    "try lexer.setToken(\(raw: enumIdent).\(raw: end.token)(\(raw: ident)(&lexer)))"
+                case let .lambda(lambda):
+                    "try lexer.setToken(\(raw: enumIdent).\(raw: end.token)(\(raw: lambda)(&lexer)))"
+                }
+            case let .createCallback(callbackDetail):
+                switch callbackDetail {
+                case let .named(ident):
+                    "try lexer.setToken(\(raw: ident)(&lexer))"
+                case let .lambda(lambda):
+                    "try lexer.setToken(\(raw: lambda)(&lexer))"
+                }
             }
         }
     }
@@ -92,8 +73,7 @@ struct Generator {
     /// Cases in the swift are grouped to reduce file length and complexity.
     /// - Parameters:
     ///     - node: the branch graph node
-    func buildBranch(node: Node.BranchContent) -> String {
-        var branches: [String] = []
+    func buildBranch(node: Node.BranchContent) throws -> CodeBlockItemListSyntax {
         var mergeCaes: [NodeId: [Node.BranchHit]] = [:]
         for (hit, nodeId) in node.branches {
             if mergeCaes[nodeId] == nil {
@@ -103,56 +83,60 @@ struct Generator {
             mergeCaes[nodeId]!.append(hit)
         }
 
-        for (nodeId, cases) in mergeCaes {
-            let caseString = cases.map { $0.toCode() }.joined(separator: ", ")
-            branches.append("""
-            case \(caseString):
-                try lexer.bump()
-                try \(generateFuncIdent(nodeId: nodeId))(&lexer)
-            """)
-        }
-
-        let miss = if let missId = node.miss {
-            "try \(generateFuncIdent(nodeId: missId))(&lexer)"
+        let miss: ExprSyntax = if let missId = node.miss {
+            "try \(raw: generateFuncIdent(nodeId: missId))(&lexer)"
         } else {
             "try lexer.error()"
         }
 
-        return """
-        guard let scalar = lexer.peak() else {
-            \(indented: miss)
-            return
-        }
+        return try CodeBlockItemListSyntax {
+            try GuardStmtSyntax("guard let scalar = lexer.peak() else {") {
+                miss
+                "return"
+            }
 
-        switch scalar {
-            \(indented: branches.joined(separator: "\n"))
+            try SwitchExprSyntax("switch scalar") {
+                for (nodeId, cases) in mergeCaes {
+                    let caseString = cases.map { $0.toCode() }.joined(separator: ", ")
+                    """
+                    case \(raw: caseString):
+                        try lexer.bump()
+                        try \(raw: generateFuncIdent(nodeId: nodeId))(&lexer)
+                    """
+                }
 
-            case _:
-            \(indented: miss)
+                """
+                case _:
+                    \(miss)
+                """
+            }
         }
-        """
     }
 
-    func buildSeq(node: Node.SeqContent) -> String {
-        let miss = if let missId = node.miss?.miss {
-            "try \(generateFuncIdent(nodeId: missId))(&lexer)"
+    func buildSeq(node: Node.SeqContent) throws -> CodeBlockItemListSyntax {
+        let miss: ExprSyntax = if let missId = node.miss?.miss {
+            "try \(raw: generateFuncIdent(nodeId: missId))(&lexer)"
         } else {
             "try lexer.error()"
         }
 
-        return """
-        guard let scalars = lexer.peak(for: \(node.seq.count)) else {
-            \(indented: miss)
-            return
-        }
+        return try CodeBlockItemListSyntax {
+            """
+            guard let scalars = lexer.peak(for: \(raw: node.seq.count)) else {
+                \(miss)
+                return
+            }
+            """
 
-        if \(node.seq.toCode()) == scalars {
-            try lexer.bump(by: \(node.seq.count))
-            try \(generateFuncIdent(nodeId: node.then))(&lexer)
-        } else {
-            \(indented: miss)
+            try IfExprSyntax("if \(raw: node.seq.toCode()) == scalars") {
+                """
+                try lexer.bump(by: \(raw: node.seq.count))
+                try \(raw: generateFuncIdent(nodeId: node.then))(&lexer)
+                """
+            } else: {
+                miss
+            }
         }
-        """
     }
 
     /// Generate function identifier based for a graph node.

--- a/Sources/KaleidoscopeMacros/KaleidoscopeBuilder.swift
+++ b/Sources/KaleidoscopeMacros/KaleidoscopeBuilder.swift
@@ -132,35 +132,31 @@ public struct KaleidoscopeBuilder: ExtensionMacro {
 
         var generator = Generator(graph: graph, enumIdent: enumIdent)
 
-        let lexerConformance: DeclSyntax = try """
-        extension \(raw: enumIdent): LexerProtocol {
-            typealias TokenType = Self
-            typealias RawSource = String
+        let lexerConformance = try ExtensionDeclSyntax("extension \(raw: enumIdent): Kaleidoscope.LexerProtocol") {
+            "typealias TokenType = Self"
+            "typealias RawSource = String"
 
-            public static func lex(_ lexer: inout LexerMachine<Self>) throws {
-                \(raw: generator.buildFunctions())
+            try FunctionDeclSyntax("public static func lex(_ lexer: inout Kaleidoscope.LexerMachine<Self>) throws") {
+                try generator.buildFunctions()
 
-                try \(raw: generator.generateFuncIdent(nodeId: rootId))(&lexer)
+                "try \(raw: generator.generateFuncIdent(nodeId: rootId))(&lexer)"
             }
 
-            public static func lexer(source: RawSource) -> LexerMachine<Self> {
-                return LexerMachine(raw: source)
-            }
-        }
-        """
-
-        let tokenResultConformance: DeclSyntax = """
-        extension \(raw: enumIdent): Into {
-            public typealias IntoType = TokenResult<\(raw: enumIdent)>
-            public func into() -> IntoType {
-                return .result(self)
+            try FunctionDeclSyntax("public static func lexer(source: RawSource) -> Kaleidoscope.LexerMachine<Self>") {
+                "return Kaleidoscope.LexerMachine(raw: source)"
             }
         }
-        """
+
+        let tokenResultConformance = try ExtensionDeclSyntax("extension \(raw: enumIdent): Kaleidoscope.Into") {
+            "public typealias IntoType = Kaleidoscope.TokenResult<\(raw: enumIdent)>"
+            try FunctionDeclSyntax("public func into() -> IntoType") {
+                "return .result(self)"
+            }
+        }
 
         return [
-            lexerConformance.cast(ExtensionDeclSyntax.self),
-            tokenResultConformance.cast(ExtensionDeclSyntax.self),
+            lexerConformance,
+            tokenResultConformance,
         ]
     }
 }

--- a/TestPlans/All.xctestplan
+++ b/TestPlans/All.xctestplan
@@ -27,6 +27,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "KaleidoscopeMacroTests",
+        "name" : "KaleidoscopeMacroTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "KaleidoscopeTests",
         "name" : "KaleidoscopeTests"
       }

--- a/Tests/KaleidoscopeMacroTests/KaleidoscopeMacroTests.swift
+++ b/Tests/KaleidoscopeMacroTests/KaleidoscopeMacroTests.swift
@@ -21,6 +21,53 @@ extension KaleidoscopeMacroTests {
                 case b
             }
             """
+        } expansion: {
+            """
+            enum Test {
+                case a
+                case b
+            }
+
+            extension Test: Kaleidoscope.LexerProtocol {
+                typealias TokenType = Self
+                typealias RawSource = String
+                public static func lex(_ lexer: inout Kaleidoscope.LexerMachine<Self>) throws {
+                    func jumpTo_0(_ lexer: inout LexerMachine<Self>) throws {
+                        guard let scalar = lexer.peak() else {
+                            try lexer.error()
+                            return
+                        }
+                        switch scalar {
+                        case 98:
+                            try lexer.bump()
+                            try jumpTo_1(&lexer)
+                        case 97:
+                            try lexer.bump()
+                            try jumpTo_2(&lexer)
+                        case _:
+                            try lexer.error()
+                        }
+                    }
+                    func jumpTo_1(_ lexer: inout LexerMachine<Self>) throws {
+                        try lexer.setToken(Test.b)
+                    }
+                    func jumpTo_2(_ lexer: inout LexerMachine<Self>) throws {
+                        try lexer.setToken(Test.a)
+                    }
+                    try jumpTo_0(&lexer)
+                }
+                public static func lexer(source: RawSource) -> Kaleidoscope.LexerMachine<Self> {
+                    return Kaleidoscope.LexerMachine(raw: source)
+                }
+            }
+
+            extension Test: Kaleidoscope.Into {
+                public typealias IntoType = Kaleidoscope.TokenResult<Test>
+                public func into() -> IntoType {
+                    return .result(self)
+                }
+            }
+            """
         }
     }
 }

--- a/Tests/KaleidoscopeMacroTests/KaleidoscopeMacroTests.swift
+++ b/Tests/KaleidoscopeMacroTests/KaleidoscopeMacroTests.swift
@@ -1,0 +1,26 @@
+//
+//  KaleidoscopeMacroTests.swift
+//  Kaleidoscope
+//
+//  Created by Larry Zeng on 1/13/26.
+//
+import MacroTesting
+import Testing
+
+extension KaleidoscopeMacroTests {
+    @Test
+    func `successful generation`() {
+        assertMacro {
+            """
+            @kaleidoscope
+            enum Test {
+                @regex("a")
+                case a
+
+                @regex("b")
+                case b
+            }
+            """
+        }
+    }
+}

--- a/Tests/KaleidoscopeMacroTests/Misc.swift
+++ b/Tests/KaleidoscopeMacroTests/Misc.swift
@@ -1,0 +1,20 @@
+//
+//  Misc.swift
+//  Kaleidoscope
+//
+//  Created by Larry Zeng on 1/13/26.
+//
+
+@testable import KaleidoscopeMacros
+import MacroTesting
+import SwiftSyntaxMacros
+import Testing
+
+let macros: [String: Macro.Type] = [
+    "kaleidoscope": KaleidoscopeBuilder.self,
+    "token": EnumCaseRegistry.self,
+    "regex": EnumCaseRegistry.self,
+]
+
+@Suite(.macros(macros, record: .failed))
+struct KaleidoscopeMacroTests {}

--- a/Tests/KaleidoscopeTests/TokenizerTests.swift
+++ b/Tests/KaleidoscopeTests/TokenizerTests.swift
@@ -6,7 +6,6 @@
 //
 
 import Kaleidoscope
-import KaleidoscopeMacros
 import Testing
 
 @kaleidoscope()


### PR DESCRIPTION
This PR refactors the macro generation to use swift syntax builder,
replacing the original raw string approach. A macro expansion test is
also added for future use.

A CI is also added, which runs for every commit on and to main. 